### PR TITLE
Support the tty for debugging and fix the Jenkins pipeline error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,8 @@ pipeline {
     }
     environment {
         PUBLISH_URL ="charts.stratumproject.org/"
-        NEW_REPO_DIR ="stratum-helm-repo"
+        OLD_REPO_DIR ="stratum-helm-repo"
+        NEW_REPO_DIR ="chart_repo"
     }
     stages {
         stage('Install tools') {

--- a/stratum/Chart.yaml
+++ b/stratum/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: stratum
-version: 0.1.7
+version: 0.1.8
 kubeVersion: ">=1.12.0"
 type: application
 keywords:

--- a/stratum/templates/daemonset.yaml
+++ b/stratum/templates/daemonset.yaml
@@ -84,6 +84,8 @@ spec:
             - name: CFG_MOUNT
               value: {{ $configDir }}
           command: ["/usr/bin/stratum-startup"]
+          tty: true
+          stdin: true
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
We used the helm-repo-tools to check and update the Helm Chart packages. We miused it before and the correct way is .
specify the OLD_REPO_DIR as an existing repo and NEW_REPO_DIR as an temp repo.

The tool will generate the Helm chart package under NEW_REPO_DIR and then compare the difference between those two repos, then move the package into OLD_REPO_DIR if necessary. 