### PR TITLE
Update SONiC version, remove workaround, and improve README

### DIFF
--- a/stratum/Chart.yaml
+++ b/stratum/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: stratum
-version: 0.2.0
+version: 0.2.1
 kubeVersion: ">=1.12.0"
 type: application
 keywords:

--- a/stratum/README.md
+++ b/stratum/README.md
@@ -11,7 +11,7 @@ Pre-built SONiC installers can be found [here](https://github.com/stratum/sonic-
 
 To install SONiC on the switch, please follow [this installation guide](https://github.com/sonic-net/SONiC/wiki/Quick-Start#installation).
 
-Note: The minimum version is 2022-07-28
+Note: The minimum version is 2022-08-12
 
 ## Kubernetes
 
@@ -23,10 +23,11 @@ Note: The minimum version is 1.17.5
 
 ## Disable SONiC services
 
-Before provisioning Stratum on switches, you need to stop SONiC services on the switch with the following command:
+Before provisioning Stratum on switches, you need to stop and disable SONiC services on the switch with the following command:
 
 ```bash
-sudo systemctl stop sonic.target
+sudo systemctl stop sonic.target sonic-delayed.target
+sudo systemctl disable sonic.target sonic-delayed.target
 ```
 
 ## Provide Chassis Config

--- a/stratum/templates/daemonset.yaml
+++ b/stratum/templates/daemonset.yaml
@@ -63,7 +63,7 @@ spec:
           env:
             - name: CFG_MOUNT
               value: {{ $configDir }}
-          command: ["/usr/bin/stratum/startup"]
+          command: ["/usr/bin/stratum-startup"]
           tty: true
           stdin: true
           securityContext:
@@ -83,8 +83,9 @@ spec:
             # For chassis config loader
             - mountPath: {{ $configDir }}
               name: config-dir
-            - mountPath: /usr/bin/stratum
+            - mountPath: /usr/bin/stratum-startup
               name: configmap-startup
+              subPath: stratum-startup
       imagePullSecrets:
         {{- range .Values.image.pullSecrets }}
         - name: {{ . | quote }}


### PR DESCRIPTION
The SONiC version 2022-08-12 contains fixes for k8s subPath which required by multiple services (e.g., fluentbit).
This PR also remove the workaround for subPath in the Stratum daemonset/pod.
This PR also improve the README with additional instruction to disable SONiC services.