### PR TITLE
Add init container to create TAP interface for Tofino CPU port

### DIFF
--- a/stratum/Chart.yaml
+++ b/stratum/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: stratum
-version: 0.2.0
+version: 0.3.0
 kubeVersion: ">=1.12.0"
 type: application
 keywords:

--- a/stratum/templates/daemonset.yaml
+++ b/stratum/templates/daemonset.yaml
@@ -33,6 +33,19 @@ spec:
           securityContext:
             privileged: true
           command: ['sh', '-c', "sysctl vm.nr_hugepages && sysctl vm.nr_hugepages=128"]
+{{ if .Values.virtual_cpu_interface.enabled }}
+        - name: init-tap-interface
+          # Creates a persistent TAP interface that can be used by other apps to
+          # send packets to the switch PCIe CPU port.
+          image: alpine
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          # The default TUN device on SONiC Tofino switches is broken. We
+          # instead use the SDE provided device in its place.
+          # The tunctl command is equivalent to: ip tuntap add {{ .Values.virtual_cpu_interface.interface_name }} mode tap
+          command: ['sh', '-c', "tunctl -f /dev/net/bf_tun -t {{ .Values.virtual_cpu_interface.interface_name }}"]
+{{ end }}
 {{ if or .Values.chassis_config .Values.external_chassis_config}}
         # Copy config from configmap to switch's local filesystem
         - name: config-getter

--- a/stratum/templates/daemonset.yaml
+++ b/stratum/templates/daemonset.yaml
@@ -98,6 +98,21 @@ spec:
               name: config-dir
             - mountPath: /usr/bin/stratum
               name: configmap-startup
+{{ if .Values.virtual_cpu_interface.enabled }}
+        # Clean up the created interface on graceful shutdown
+        - name: del-tap-interface
+          image: alpine
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          # The main command does nothing except just wait for the container to
+          # be deleted. Actual cleanup happens in the preStop hook.
+          command: ['sh', '-c', "sleep 99999d"]
+          lifecycle:
+            preStop:
+              exec:
+                command: ['sh', '-c', "kill -s TERM $(pgrep stratum_bfrt); wait $(pgrep stratum_bfrt); tunctl -f /dev/net/bf_tun -d {{ .Values.virtual_cpu_interface.interface_name }}"]
+{{ end }}
       imagePullSecrets:
         {{- range .Values.image.pullSecrets }}
         - name: {{ . | quote }}

--- a/stratum/templates/daemonset.yaml
+++ b/stratum/templates/daemonset.yaml
@@ -111,7 +111,7 @@ spec:
           lifecycle:
             preStop:
               exec:
-                command: ['sh', '-c', "kill -s TERM $(pgrep stratum_bfrt); wait $(pgrep stratum_bfrt); tunctl -f /dev/net/bf_tun -d {{ .Values.virtual_cpu_interface.interface_name }}"]
+                command: ['sh', '-c', "tunctl -f /dev/net/bf_tun -d {{ .Values.virtual_cpu_interface.interface_name }}"]
 {{ end }}
       imagePullSecrets:
         {{- range .Values.image.pullSecrets }}

--- a/stratum/values.yaml
+++ b/stratum/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: stratumproject/stratum-bfrt
-  tag: 22.07.18-9.7.0
+  tag: 23.01.27-9.10.0
   registry: docker.io
   pullPolicy: IfNotPresent
   # Optional.
@@ -20,6 +20,9 @@ extraParams:
   # - "-read_req_log_file=\"\""
   - "-v=0"
   - "-minloglevel=0"
+  # If virtual_cpu_interface.enabled = true, for stratum-bfrt only
+  # - "-experimental_bfrt_tofino_virtual_cpu_interface_name=tapSwCpu"
+
 
 # Specify nodeSelector to pin Stratum to switches only
 #
@@ -35,6 +38,12 @@ extraParams:
 
 podsecuritypolicy:
   enabled: false
+
+# Expose the Tofino PCIe CPU port as a Linux interface. Requires the flag
+# -experimental_bfrt_tofino_virtual_cpu_interface_name=<...> for full effect.
+virtual_cpu_interface:
+  enabled: false
+  interface_name: tapSwCpu
 
 
 # # If the chassis_config comes from other deployment (e.g. Kustomize),


### PR DESCRIPTION
This PR adds a config option the chart to enable the workaround for the broken Ethernet CPU port on Wedge100-BF switches. It exposes the PCIe port as a Linux TAP interface.